### PR TITLE
Default build command to cmd_build

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -16,6 +16,11 @@ cmd_build() {
          --mod=vendor $MAIN_PACKAGE
 }
 
+if [ $# -eq "0" ]; then
+    cmd_build
+    exit 0
+fi
+
 case $1 in
 build)
   ./scripts/bootstrap


### PR DESCRIPTION
If no argument is passed to ./scripts/build, invoke cmd_build