### PR TITLE
Change CI container to ubuntu-2204-ci

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,4 +5,4 @@ steps:
       - ./scripts/cibuild build
       - TEST_FAST=true ./scripts/test
     agents:
-      container_image: ubuntu-2110-ci
+      container_image: ubuntu-2204-ci

--- a/.buildkite/scheduled-build.yaml
+++ b/.buildkite/scheduled-build.yaml
@@ -1,6 +1,6 @@
 agents:
   queue: default
-  container_image: ubuntu-2110-ci
+  container_image: ubuntu-2204-ci
 
 steps:
   - label: "Scheduled build"


### PR DESCRIPTION
22.04 is preferred; it is a long-term release (LTS). Refs [sc-12654]